### PR TITLE
retire asset in Teamdynamix with host before_destroy hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 A Foreman Plugin for TeamDynamix. It manages a host lifecycle as a corresponding Asset in TeamDynamix.
 
 ## Configuration
-[:api][:create]
-* All attributes are passed as is to the Team Dynamix API while creating an asset for the Foreman host.
+[:api][:create] or [:delete]
+* All attributes are passed as is to the TeamDynamix API while creating or deleting a TeamDynamix Asset.
+* An asset gets created or deleted with the Foreman Host create or delete lifecycle event.
 
 [:fields]
 * A link to the asset in Teamdynamix is displayed by default, as first field labelled as URI
@@ -20,6 +21,8 @@ A Foreman Plugin for TeamDynamix. It manages a host lifecycle as a corresponding
     :create:
       :StatusID: integer_id
       :OwningCustomerName: string
+    :delete
+      :StatusID: integer_id
   :title: 'custom title for Team Dynamix Tab'
   :fields:
     Asset ID: ID

--- a/app/models/concerns/foreman_teamdynamix/host_extensions.rb
+++ b/app/models/concerns/foreman_teamdynamix/host_extensions.rb
@@ -8,6 +8,7 @@ module ForemanTeamdynamix
 
     included do
       after_validation :create_teamdynamix_asset, on: :create
+      before_destroy :retire_teamdynamix_asset
       validates :teamdynamix_asset_id, uniqueness: { :allow_blank => true }
     end
 
@@ -16,7 +17,14 @@ module ForemanTeamdynamix
     def create_teamdynamix_asset
       asset = td_api.create_asset(self)
       self.teamdynamix_asset_id = asset['ID']
+    rescue StandardError => e
+      errors.add(:base, e.message)
     end
 
+    def retire_teamdynamix_asset
+      td_api.retire_asset(self.teamdynamix_asset_id) if self.teamdynamix_asset_id
+    rescue StandardError => e
+      errors.add(:base, e.message)
+    end
   end
 end

--- a/app/models/concerns/foreman_teamdynamix/host_extensions.rb
+++ b/app/models/concerns/foreman_teamdynamix/host_extensions.rb
@@ -18,13 +18,15 @@ module ForemanTeamdynamix
       asset = td_api.create_asset(self)
       self.teamdynamix_asset_id = asset['ID']
     rescue StandardError => e
-      errors.add(:base, e.message)
+      errors.add(:base, _("Could not create the asset for the host in TeamDynamix: #{e.message}"))
+      return false
     end
 
     def retire_teamdynamix_asset
       td_api.retire_asset(self.teamdynamix_asset_id) if self.teamdynamix_asset_id
     rescue StandardError => e
-      errors.add(:base, e.message)
+      errors.add(:base, _("Could not retire the asset for the host in TeamDynamix: #{e.message}"))
+      return false
     end
   end
 end

--- a/lib/teamdynamix_api.rb
+++ b/lib/teamdynamix_api.rb
@@ -26,6 +26,11 @@ class TeamdynamixApi
     rest(:post, uri, create_asset_payload(host))
   end
 
+  def retire_asset(asset_id)
+    uri = URI.parse(API_URL + "/#{APP_ID}/assets/#{asset_id}")
+    rest(:post, uri, retire_asset_payload(asset_id))
+  end
+
   # Gets a list of assets matching the specified criteria. (IEnumerable(Of TeamDynamix.Api.Assets.Asset))
   def search_asset(search_params)
     uri = URI.parse(API_URL + "/#{APP_ID}/assets/search")
@@ -93,16 +98,21 @@ class TeamdynamixApi
     token.match(/^[a-zA-Z0-9\.\-\_]*$/)
   end
 
+  def retire_asset_payload(asset_id)
+    asset = get_asset(asset_id)
+    asset.merge!(API_CONFIG[:delete].stringify_keys)
+  end
+
   def create_asset_payload host
     ensure_configured_create_params
     payload = { AppID: APP_ID, 
                 SerialNumber: host.name,
                 Name: host.fqdn
               }
-    payload.merge!(API_CONFIG[:create])      
+    payload.merge!(API_CONFIG[:create].stringify_keys)
     payload.merge(Attributes: create_asset_attributes(host))
   end
-  
+
   def create_asset_attributes(host)
     [
       {

--- a/test/fake_teamdynamix_api.rb
+++ b/test/fake_teamdynamix_api.rb
@@ -4,7 +4,14 @@ class FakeTeamdynamixApi
     get_asset
   end
 
-  # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+  def search_asset(*)
+    Array.wrap(get_asset)
+  end
+
+  def retire_asset(*)
+    true
+  end
+
   def get_asset(*)
     JSON.parse(File.read(File.join(File.dirname(__FILE__), 'sample_asset.json')))
   end

--- a/test/lib/teamdynamix_api_test.rb
+++ b/test/lib/teamdynamix_api_test.rb
@@ -4,7 +4,30 @@ class TeamdynamixApiTest < ActiveSupport::TestCase
   let(:subject) { TeamdynamixApi.new }
   let(:app_id) { SETTINGS[:teamdynamix][:api][:id] }
   let(:host) { FactoryBot.build(:host, :managed) }
-  # rubocop:disable Style/StringLiterals
+  let(:host_name) { 'delete.foreman_teamdynamix.com' }
+  before do
+    host.name = host_name
+  end
+
+  describe '#retire_asset' do
+    let(:status_id) { 642 }
+    before do
+      SETTINGS[:teamdynamix][:api][:delete] = { StatusID: status_id }
+    end
+    let(:td_asset_id) do
+      test_assets = subject.search_asset({}).select do |asset|
+        asset['Name'] == host_name
+      end
+      test_assets = [subject.create_asset(host)] if test_assets.blank?
+      test_assets.first['ID']
+    end
+    it 'marks the asset retired in Team Dynamix' do
+      assert_nothing_raised do
+        asset = subject.retire_asset(td_asset_id)
+        assert_equal(asset['StatusID'], status_id)
+      end
+    end
+  end
 
   describe '#create_asset' do
     context 'Valid Request' do
@@ -81,4 +104,5 @@ class TeamdynamixApiTest < ActiveSupport::TestCase
       end
     end
   end
+
 end

--- a/test/models/host_extensions_test.rb
+++ b/test/models/host_extensions_test.rb
@@ -1,20 +1,18 @@
 require 'test_helper'
 
 class HostExtensionsTests < ActiveSupport::TestCase
-  let(:host) { FactoryBot.create(:host, :managed) }
   let(:td_api) { FakeTeamdynamixApi.new }
   before do
     Host::Managed.any_instance.stubs(:td_api).returns(td_api)
   end
 
   describe '#create' do
+    let(:host) { FactoryBot.create(:host, :managed) }
     it 'triggers after_create callback on Host::Managed model' do
-      host = FactoryBot.create(:host, :managed)
       assert_send([Host::Managed, :after_validation, :create_teamdynamix_asset])
     end
 
     it 'calls Teamdynamix API to create an asset' do
-      host = FactoryBot.create(:host, :managed)
       assert_send([td_api, :create_asset, host])
     end
 
@@ -22,4 +20,24 @@ class HostExtensionsTests < ActiveSupport::TestCase
       assert_not_nil(host.teamdynamix_asset_id)
     end
   end
+
+  describe '#destroy' do
+    let(:host) { FactoryBot.create(:host, :managed) }
+    before do
+      host.destroy
+    end
+    it 'triggers before_destroy callback' do
+      assert_send([Host::Managed, :before_destroy, :retire_teamdynamix_asset])
+    end
+
+    it 'calls Teamdynamix API to retire an asset' do
+      assert_send([td_api, :retire_asset, host.td_asset_id])
+    end
+
+    it 'sets host#StatusID' do
+      skip('this need actual api interaction')
+      assert(host.td_asset_id, SETTINGS[:teamdynamix][:api][:delete][:StatusID])
+    end
+  end
+
 end

--- a/test/sample_asset.json
+++ b/test/sample_asset.json
@@ -16,7 +16,7 @@
   "LocationRoomName": "None",
   "Tag": null,
   "SerialNumber": "Banner Advancement",
-  "Name": "",
+  "Name": "delete.foreman_teamdynamix.com",
   "PurchaseCost": 0,
   "AcquisitionDate": "0001-01-01T05:00:00Z",
   "ExpectedReplacementDate": "0001-01-01T05:00:00Z",


### PR DESCRIPTION
any failure in creating/deleing asset in TD will be displayed to the user via AR Errors