### PR TITLE
use singleton class for teamdynamix_api to allow auth token reuse

### DIFF
--- a/app/models/concerns/foreman_teamdynamix/host_extensions.rb
+++ b/app/models/concerns/foreman_teamdynamix/host_extensions.rb
@@ -3,7 +3,7 @@ module ForemanTeamdynamix
     extend ActiveSupport::Concern
 
     def td_api
-      @td_api ||= TeamdynamixApi.new
+      @td_api ||= TeamdynamixApi.instance
     end
 
     included do

--- a/test/models/host_extensions_test.rb
+++ b/test/models/host_extensions_test.rb
@@ -31,12 +31,7 @@ class HostExtensionsTests < ActiveSupport::TestCase
     end
 
     it 'calls Teamdynamix API to retire an asset' do
-      assert_send([td_api, :retire_asset, host.td_asset_id])
-    end
-
-    it 'sets host#StatusID' do
-      skip('this need actual api interaction')
-      assert(host.td_asset_id, SETTINGS[:teamdynamix][:api][:delete][:StatusID])
+      assert_send([td_api, :retire_asset, host.teamdynamix_asset_id])
     end
   end
 

--- a/test/services/teamdynamix_api_test.rb
+++ b/test/services/teamdynamix_api_test.rb
@@ -2,7 +2,7 @@ require 'test_plugin_helper'
 # rubocop:disable Metrics/ClassLength
 class TeamdynamixApiTest < ActiveSupport::TestCase
   # rubocop:enable Metrics/ClassLength
-  let(:subject) { TeamdynamixApi.new }
+  let(:subject) { TeamdynamixApi.instance }
   let(:api_config) { SETTINGS[:teamdynamix][:api] }
   let(:app_id) { api_config[:id] }
   let(:api_url) { api_config[:url] }
@@ -80,7 +80,7 @@ class TeamdynamixApiTest < ActiveSupport::TestCase
         asset_ci_desc = asset['Attributes'].select { |attrib| attrib['Name'] == 'mu.ci.Description' }[0]['Value']
         assert_equal(asset_ci_desc, asset_ci_desc_expectation)
         asset_ci_lifecycle_status = asset['Attributes'].select { |attrib| attrib['Name'] == 'mu.ci.Lifecycle Status' }[0]['Value']
-        assert_equal(asset_ci_lifecycle_status.to_s, subject.send(:get_lifecycle_status).to_s)
+        assert_equal(asset_ci_lifecycle_status.to_s, subject.send(:lifecycle_status).to_s)
       end
     end
 
@@ -104,11 +104,11 @@ class TeamdynamixApiTest < ActiveSupport::TestCase
     end
   end
 
-  describe '#auth_token' do
+  describe '#request_token' do
     describe 'valida credentials' do
     end
     it 'returns a bearer token if credentials are correct' do
-      assert_not_nil(subject.send(:auth_token))
+      assert_not_nil(subject.send(:request_token))
     end
 
     describe 'invalid credentials' do
@@ -123,7 +123,7 @@ class TeamdynamixApiTest < ActiveSupport::TestCase
       end
       it 'raises error with status 403' do
         assert_raises_with_message(RuntimeError, error) do
-          subject.send(:auth_token)
+          subject.send(:request_token)
         end
       end
     end


### PR DESCRIPTION
rubocop fixes: